### PR TITLE
Added the  --single-transaction flag to mysqldump

### DIFF
--- a/mysql-dump.sh
+++ b/mysql-dump.sh
@@ -51,7 +51,7 @@ db_backup(){
                 FILE_PATH="${LOCAL_BACKUP_DIR}/${CURRENT_DATE}/"
                 FILENAMEPATH="$FILE_PATH$FILE_NAME"
                 [ $VERBOSE -eq 1 ] && echo -en "Database> $db... \n"
-                ${MYSQLDUMP} ${CREDENTIALS} -h ${MYSQL_HOST} -P $MYSQL_PORT $db | ${GZIP} -9 > $FILENAMEPATH
+                ${MYSQLDUMP} ${CREDENTIALS} --single-transaction -h ${MYSQL_HOST} -P $MYSQL_PORT $db | ${GZIP} -9 > $FILENAMEPATH
                 echo "$db   :: `du -sh ${FILENAMEPATH}`"  >> ${LOGFILENAME}
                 [ $FTP_ENABLE -eq 1 ] && ftp_backup
                 [ $SFTP_ENABLE -eq 1 ] && sftp_backup


### PR DESCRIPTION
The  --single-transaction flag was added to mysqldump command. Without this option, the database becomes unusable for the period of the backup, which is not ideal in a Live environment
The --single-transaction flag will start a transaction before running. Rather than lock the entire database, this will let mysqldump read the database in the current state at the time of the transaction, making for a consistent data dump.